### PR TITLE
Add win64 builds

### DIFF
--- a/.github/workflows/build-msbuild.yaml
+++ b/.github/workflows/build-msbuild.yaml
@@ -7,18 +7,38 @@ on:
 jobs:
   build-msbuild:
     # TODO: automated testing
-    env:
-      BUILD_PLATFORM: "x86"
-      BUILD_CONFIGURATION: Release
-      OPENSSL_BUILD_PLATFORM: VC-WIN32
-      ARCH: win32
     runs-on: windows-latest
     strategy:
       matrix:
         sln:
           - vs2015
+        platform:
+          - win32
+          - win64
+      fail-fast: false
+
 
     steps:
+      - name: Set env win32
+        if: |
+          matrix.platform == 'win32'
+        shell: bash
+        run: |
+          echo "ARCH=win32" >> $GITHUB_ENV
+          echo "BUILD_PLATFORM=x86" >> $GITHUB_ENV
+          echo "BUILD_CONFIGURATION=Release" >> $GITHUB_ENV
+          echo "OPENSSL_BUILD_PLATFORM=VC-WIN32" >> $GITHUB_ENV
+
+      - name: Set env win64
+        if: |
+          matrix.platform == 'win64'
+        shell: bash
+        run: |
+          echo "ARCH=win64" >> $GITHUB_ENV
+          echo "BUILD_PLATFORM=x64" >> $GITHUB_ENV
+          echo "BUILD_CONFIGURATION=Release" >> $GITHUB_ENV
+          echo "OPENSSL_BUILD_PLATFORM=VC-WIN64A" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -50,25 +70,37 @@ jobs:
           cd dep
           git clone -b OpenSSL_1_1_1-stable --depth 1 https://github.com/openssl/openssl.git
           cd openssl
-          md x86
-          cd x86
+          md ${{env.BUILD_PLATFORM}}
+          cd ${{env.BUILD_PLATFORM}}
           perl ..\Configure ${{env.OPENSSL_BUILD_PLATFORM}} no-shared
           nmake /S
 
       - name: Build Project
         run: |
           msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{matrix.sln}} /p:Platform=${{env.BUILD_PLATFORM}}
+
+      - name: Move Output
+        if: |
+          matrix.platform == 'win64'
+        run: |
+          # no idea why OutputPath isn't working
+          md ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}
+          cp ${{matrix.sln}}\x64\${{env.BUILD_CONFIGURATION}}\*.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}
           dir ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}
 
       - name: Store
         uses: actions/upload-artifact@v4
         with:
-          name: gm-apclientpp-${{matrix.sln}}
+          name: gm-apclientpp-${{matrix.sln}}-${{matrix.platform}}
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\gm-apclientpp.dll
 
       - name: Set env
         if: ${{ github.ref_type == 'tag' }}
         run: echo "RELEASE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Package
+        if: ${{ github.ref_type == 'tag' }}
+        run: Compress-Archive -Path ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\gm-apclientpp.dll -DestinationPath gm-apclientpp-${{matrix.platform}}.zip
 
       - name: Release
         if: ${{ github.ref_type == 'tag' }}
@@ -76,7 +108,7 @@ jobs:
         with:
           draft: true
           name: gm-apclientpp ${{ env.RELEASE_TAG }}
-          files: ${{matrix.sln}}/${{env.BUILD_CONFIGURATION}}/gm-apclientpp.dll
+          files: gm-apclientpp-${{matrix.platform}}.zip
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,13 @@ jobs:
 
   build-vs2022:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        sln:
+          - vs2015
+        platform:
+          - x86
+          - x64
 
     steps:
       - name: Checkout code
@@ -36,11 +43,11 @@ jobs:
       - name: Patch project
         shell: bash
         run: |
-          sed -i 's/<\/AdditionalOptions>/ \/DWSWRAP_NO_SSL<\/AdditionalOptions>/g' vs2015/gm-apclientpp.vcxproj
-          sed -i 's/<PlatformToolset>v140<\/PlatformToolset>/<PlatformToolset>v143<\/PlatformToolset>/' vs2015/gm-apclientpp.vcxproj
-          sed -i 's/libssl.lib;libcrypto.lib;//g' vs2015/gm-apclientpp.vcxproj
+          sed -i 's/<\/AdditionalOptions>/ \/DWSWRAP_NO_SSL<\/AdditionalOptions>/g' ${{matrix.sln}}/gm-apclientpp.vcxproj
+          sed -i 's/<PlatformToolset>v140<\/PlatformToolset>/<PlatformToolset>v143<\/PlatformToolset>/' ${{matrix.sln}}/gm-apclientpp.vcxproj
+          sed -i 's/libssl.lib;libcrypto.lib;//g' ${{matrix.sln}}/gm-apclientpp.vcxproj
       - name: Add MSBuild to PATH
         uses: ilammy/msvc-dev-cmd@v1
       - name: Build
         run: |
-          msbuild /m /p:Configuration=Release vs2015 /p:Platform=x86
+          msbuild /m /p:Configuration=Release ${{matrix.sln}} /p:Platform=${{matrix.platform}}

--- a/vs2015/gm-apclientpp.sln
+++ b/vs2015/gm-apclientpp.sln
@@ -13,8 +13,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.ActiveCfg = Debug|Win64
-		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.Build.0 = Debug|Win64
+		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.ActiveCfg = Debug|x64
+		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.Build.0 = Debug|x64
 		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x86.ActiveCfg = Debug|Win32
 		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x86.Build.0 = Debug|Win32
 		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Release|x64.ActiveCfg = Release|x64

--- a/vs2015/gm-apclientpp.sln
+++ b/vs2015/gm-apclientpp.sln
@@ -13,8 +13,8 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.ActiveCfg = Debug|x64
-		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.Build.0 = Debug|x64
+		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.ActiveCfg = Debug|Win64
+		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x64.Build.0 = Debug|Win64
 		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x86.ActiveCfg = Debug|Win32
 		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Debug|x86.Build.0 = Debug|Win32
 		{50027276-8B71-45F6-89D6-6F0A57DCCFC6}.Release|x64.ActiveCfg = Release|x64

--- a/vs2015/gm-apclientpp.vcxproj
+++ b/vs2015/gm-apclientpp.vcxproj
@@ -9,6 +9,14 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>14.0</VCProjectVersion>
@@ -32,6 +40,20 @@
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -41,6 +63,12 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -53,6 +81,16 @@
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>$(ProjectDir)..\subprojects\json\include;$(ProjectDir)..\subprojects\valijson\include;$(ProjectDir)..\subprojects\wswrap\include;$(ProjectDir)..\subprojects\apclientpp;$(ProjectDir)..\subprojects\asio\include;$(ProjectDir)..\subprojects\websocketpp;$(ProjectDir)..\subprojects;$(ProjectDir)..\dep\openssl\include;$(ProjectDir)..\dep\openssl\x86\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
     <LibraryPath>$(ProjectDir)..\dep\openssl\x86;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(ProjectDir)..\subprojects\json\include;$(ProjectDir)..\subprojects\valijson\include;$(ProjectDir)..\subprojects\wswrap\include;$(ProjectDir)..\subprojects\apclientpp;$(ProjectDir)..\subprojects\asio\include;$(ProjectDir)..\subprojects\websocketpp;$(ProjectDir)..\subprojects;$(ProjectDir)..\dep\dep\openssl\include;$(ProjectDir)..\dep\openssl\x64\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <LibraryPath>$(ProjectDir)..\dep\openssl\x64;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(ProjectDir)..\subprojects\json\include;$(ProjectDir)..\subprojects\valijson\include;$(ProjectDir)..\subprojects\wswrap\include;$(ProjectDir)..\subprojects\apclientpp;$(ProjectDir)..\subprojects\asio\include;$(ProjectDir)..\subprojects\websocketpp;$(ProjectDir)..\subprojects;$(ProjectDir)..\dep\openssl\include;$(ProjectDir)..\dep\openssl\x64\include;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+    <LibraryPath>$(ProjectDir)..\dep\openssl\x64;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -92,6 +130,51 @@
     </ClCompile>
     <Link>
       <TargetMachine>MachineX86</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalDependencies>libssl.lib;libcrypto.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <Optimization>Disabled</Optimization>
+      <ConformanceMode>true</ConformanceMode>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader />
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions) /std:c++14 /wd4996 /Gd /DASIO_STANDALONE /DGM_APCLIENTPP_EXPORTS</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX64</TargetMachine>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>libssl.lib;libcrypto.lib;crypt32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ConformanceMode>true</ConformanceMode>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader />
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+      <AdditionalOptions>/Zc:__cplusplus %(AdditionalOptions) /std:c++14 /wd4996 /Gd /DASIO_STANDALONE /DGM_APCLIENTPP_EXPORTS</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <TargetMachine>MachineX64</TargetMachine>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>


### PR DESCRIPTION
* Adds a target for win64 to the project - needs static openssl libs in ../dep/openssl/x64
* rework workflow to build both win32 and win64 builds